### PR TITLE
[Fix] OSS Bucket query to check logging settings returns wrong results. Closes 108

### DIFF
--- a/alicloud/table_alicloud_oss_bucket.go
+++ b/alicloud/table_alicloud_oss_bucket.go
@@ -73,7 +73,7 @@ func tableAlicloudOssBucket(ctx context.Context) *plugin.Table {
 				Name:        "logging",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getBucketLogging,
-				Transform:   transform.FromField("LoggingXML.LoggingEnabled"),
+				Transform:   transform.FromField("LoggingEnabled"),
 				Description: "Indicates the container used to store access logging configuration of a bucket.",
 			},
 			{


### PR DESCRIPTION
```
> select
  name,
  logging ->> 'TargetBucket' as target_bucket
from
  alicloud_oss_bucket
where
  logging ->> 'TargetBucket' = name;
+----------------+----------------+
| name           | target_bucket  |
+----------------+----------------+
| cis-test-mar12 | cis-test-mar12 |
+----------------+----------------+
```