### PR TITLE
fix relative url in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ from
 
 ## Documentation
 
-- **[Table definitions & examples →](alicloud/tables)**
+- **[Table definitions & examples →](/plugins/turbot/alicloud/tables)**
 
 ## Get started
 


### PR DESCRIPTION
changed link in index.md to be qualified from the root of the website 

`alicloud/tables` to `/plugins/turbot/alicloud/tables`