### PR TITLE
Add cluster namespace and arn for table alicloud_cs_kubernetes_cluster closes #159

### DIFF
--- a/alicloud-test/tests/alicloud_cs_kubernetes_cluster/test-get-query.sql
+++ b/alicloud-test/tests/alicloud_cs_kubernetes_cluster/test-get-query.sql
@@ -1,3 +1,3 @@
 select name, cluster_id, size
 from alicloud_cs_kubernetes_cluster
-where cluster_id = '{{ output.cluster_id.value }}' and region = '{{ output.region.value }}';
+where cluster_id = '{{ output.cluster_id.value }}';

--- a/alicloud-test/tests/alicloud_cs_kubernetes_cluster/test-list-query.sql
+++ b/alicloud-test/tests/alicloud_cs_kubernetes_cluster/test-list-query.sql
@@ -1,3 +1,3 @@
 select name, cluster_id, state
 from alicloud_cs_kubernetes_cluster
-where akas::text = '["{{ output.resource_aka.value }}"]' and region = '{{ output.region.value }}';
+where akas::text = '["{{ output.resource_aka.value }}"]';

--- a/alicloud-test/tests/alicloud_cs_kubernetes_cluster/test-turbot-query.sql
+++ b/alicloud-test/tests/alicloud_cs_kubernetes_cluster/test-turbot-query.sql
@@ -1,3 +1,3 @@
 select name, akas, title
 from alicloud_cs_kubernetes_cluster
-where cluster_id = '{{ output.cluster_id.value }}' and region = '{{ output.region.value }}';
+where cluster_id = '{{ output.cluster_id.value }}';

--- a/alicloud-test/tests/alicloud_cs_kubernetes_cluster/variables.tf
+++ b/alicloud-test/tests/alicloud_cs_kubernetes_cluster/variables.tf
@@ -62,5 +62,5 @@ output "region" {
 }
 
 output "resource_aka" {
-  value = "acs:cs:${var.alicloud_region}:${data.alicloud_caller_identity.current.account_id}:container/${var.resource_name}"
+  value = "arn:acs:cs:${var.alicloud_region}:${data.alicloud_caller_identity.current.account_id}:cluster/${alicloud_cs_managed_kubernetes.named_test_resource[0].id}"
 }

--- a/alicloud/table_alicloud_cs_kubernetes_cluster.go
+++ b/alicloud/table_alicloud_cs_kubernetes_cluster.go
@@ -3,9 +3,7 @@ package alicloud
 import (
 	"context"
 	"encoding/json"
-	"os"
 
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cs"
@@ -283,9 +281,9 @@ func tableAlicloudCsKubernetesCluster(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("meta_data"),
 			},
 			{
-				Name:      "cluster_name_spaces",
+				Name:      "cluster_namespace",
 				Type:      proto.ColumnType_JSON,
-				Hydrate:   getCsKubernetesClusterNameSpaces,
+				Hydrate:   getCsKubernetesClusterNamespace,
 				Transform: transform.FromValue(),
 			},
 			{
@@ -456,9 +454,9 @@ func getCsKubernetesClusterLog(ctx context.Context, d *plugin.QueryData, h *plug
 	return nil, nil
 }
 
-func getCsKubernetesClusterNameSpaces(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+func getCsKubernetesClusterNamespace(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
-	plugin.Logger(ctx).Trace("getCsKubernetesClusterNameSpaces")
+	plugin.Logger(ctx).Trace("getCsKubernetesClusterNamespace")
 
 	var id string
 	if h.Item != nil {
@@ -468,9 +466,7 @@ func getCsKubernetesClusterNameSpaces(ctx context.Context, d *plugin.QueryData, 
 		id = d.KeyColumnQuals["cluster_id"].GetStringValue()
 	}
 
-	accessKey := os.Getenv("ALICLOUD_ACCESS_KEY")
-	secretAccess := os.Getenv("ALICLOUD_SECRET_KEY")
-	client, err := sdk.NewClientWithAccessKey(region, accessKey, secretAccess)
+	client, err := ContainerService(ctx, d, region)
 	if err != nil {
 		return nil, nil
 	}

--- a/alicloud/table_alicloud_cs_kubernetes_cluster.go
+++ b/alicloud/table_alicloud_cs_kubernetes_cluster.go
@@ -283,9 +283,9 @@ func tableAlicloudCsKubernetesCluster(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("meta_data"),
 			},
 			{
-				Name: "cluster_name_spaces",
-				Type: proto.ColumnType_JSON,
-				Hydrate: getCsKubernetesClusterNameSpaces,
+				Name:      "cluster_name_spaces",
+				Type:      proto.ColumnType_JSON,
+				Hydrate:   getCsKubernetesClusterNameSpaces,
 				Transform: transform.FromValue(),
 			},
 			{
@@ -481,11 +481,11 @@ func getCsKubernetesClusterNameSpaces(ctx context.Context, d *plugin.QueryData, 
 	request.Domain = "cs.aliyuncs.com"
 	request.Version = "2015-12-15"
 	request.PathPattern = "/k8s/" + id + "/namespaces"
-  request.Headers["Content-Type"] = "application/json"
-  request.QueryParams["RegionId"] = region
+	request.Headers["Content-Type"] = "application/json"
+	request.QueryParams["RegionId"] = region
 	body := `{}`
 	request.Content = []byte(body)
-	
+
 	response, err := client.ProcessCommonRequest(request)
 	if err != nil {
 		return nil, nil

--- a/alicloud/table_alicloud_cs_kubernetes_cluster.go
+++ b/alicloud/table_alicloud_cs_kubernetes_cluster.go
@@ -394,11 +394,7 @@ func getCsKubernetesCluster(ctx context.Context, d *plugin.QueryData, h *plugin.
 		plugin.Logger(ctx).Error("getCsKubernetesCluster", "connection_error", err)
 		return nil, err
 	}
-	// region := d.KeyColumnQuals["region"].GetStringValue()
-
-	// if region != matrixRegion {
-	// 	return nil, nil
-	// }
+	
 	var id string
 	if h.Item != nil {
 		clusterData := h.Item.(map[string]interface{})

--- a/alicloud/table_alicloud_cs_kubernetes_cluster.go
+++ b/alicloud/table_alicloud_cs_kubernetes_cluster.go
@@ -26,7 +26,6 @@ func tableAlicloudCsKubernetesCluster(ctx context.Context) *plugin.Table {
 			KeyColumns: plugin.SingleColumn("cluster_id"),
 			Hydrate:    getCsKubernetesCluster,
 		},
-		// GetMatrixItem: BuildRegionList,
 		Columns: []*plugin.Column{
 			{
 				Name:        "name",


### PR DESCRIPTION
### Note:

For the list call we don't need region for getting the resource list, let say if we have 2 regions in our `alicloud.spc` file then  the list call is performing once per region so it is listing out the same resource twice, so we have to fix by making the list call once for all regions, this PR contains this fix


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/alicloud_cs_kubernetes_cluster []

PRETEST: tests/alicloud_cs_kubernetes_cluster

TEST: tests/alicloud_cs_kubernetes_cluster
Running terraform
data.alicloud_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
alicloud_vpc.named_test_resource: Creating...
alicloud_vpc.named_test_resource: Creation complete after 7s [id=vpc-0xitm6bjsu908exq0eqt9]
alicloud_vswitch.named_test_resource: Creating...
alicloud_vswitch.named_test_resource: Creation complete after 7s [id=vsw-0xikidgnzuc2i1ohqaerb]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Creating...
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [9m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Creation complete after 9m5s [id=c816294fbed4b4d7e83a0eb8ce5ed695a]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

cluster_id = c816294fbed4b4d7e83a0eb8ce5ed695a
region = us-east-1
resource_aka = acs:cs:us-east-1:5982111499156037:container/turbottest54274
resource_name = turbottest54274

Running SQL query: test-get-query.sql
[
  {
    "cluster_id": "c816294fbed4b4d7e83a0eb8ce5ed695a",
    "name": "turbottest54274",
    "size": 2
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "cluster_id": "c816294fbed4b4d7e83a0eb8ce5ed695a",
    "name": "turbottest54274",
    "state": "running"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "acs:cs:us-east-1:5982111499156037:container/turbottest54274"
    ],
    "name": "turbottest54274",
    "title": "turbottest54274"
  }
]
✔ PASSED

POSTTEST: tests/alicloud_cs_kubernetes_cluster

TEARDOWN: tests/alicloud_cs_kubernetes_cluster

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select name, cluster_id, cluster_name_spaces from alicloud_cs_kubernetes_cluster;

```

```
+-------------+-----------------------------------+---------------------------------------------------------------------------------+
| name        | cluster_id                        | cluster_name_spaces                                                             |
+-------------+-----------------------------------+---------------------------------------------------------------------------------+
| kub-cluster | c1513718da3aa42d3938adaf7e96b7c79 | ["arms-prom","default","kube-node-lease","kube-public","kube-system","__all__"] |
+-------------+-----------------------------------+---------------------------------------------------------------------------------+
```
</details>
