### PR TITLE
add column cs_user_permissions for table alicloud_ram_user. Closes #181

### DIFF
--- a/alicloud/table_alicloud_ram_user.go
+++ b/alicloud/table_alicloud_ram_user.go
@@ -109,10 +109,10 @@ func tableAlicloudRAMUser(ctx context.Context) *plugin.Table {
 				Transform:   transform.FromField("Policies.Policy"),
 			},
 			{
-				Name:        "cs_user_permission",
-				Description: "User permissions for container service kubernetes clusters.",
+				Name:        "cs_user_permissions",
+				Description: "User permissions for Container Service Kubernetes clusters.",
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getCsUserPermission,
+				Hydrate:     getCsUserPermissions,
 				Transform:   transform.FromValue(),
 			},
 			{
@@ -312,13 +312,13 @@ func getUserAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 	return []string{"acs:ram::" + accountID + ":user/" + data.UserName}, nil
 }
 
-func getCsUserPermission(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getCsUserPermission")
+func getCsUserPermissions(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getCsUserPermissions")
 
 	// Create service connection
 	client, err := RAMService(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("getCsUserPermission", "connection_error", err)
+		plugin.Logger(ctx).Error("getCsUserPermissions", "connection_error", err)
 		return nil, err
 	}
 
@@ -336,7 +336,7 @@ func getCsUserPermission(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 
 	response, err := client.ProcessCommonRequest(request)
 	if serverErr, ok := err.(*errors.ServerError); ok {
-		plugin.Logger(ctx).Error("getCsUserPermission", "query_error", serverErr, "request", request)
+		plugin.Logger(ctx).Error("getCsUserPermissions", "query_error", serverErr, "request", request)
 		return nil, err
 	}
 

--- a/docs/tables/alicloud_ram_user.md
+++ b/docs/tables/alicloud_ram_user.md
@@ -63,7 +63,7 @@ select
 from
   alicloud_ram_user,
   jsonb_array_elements(attached_policy) as policies
-where 
+where
   policies ->> 'PolicyName' = 'AdministratorAccess';
 ```
 
@@ -78,4 +78,16 @@ from
   alicloud_ram_user
 where
   not mfa_enabled;
+```
+
+### List all the users for whom role-based access control (RBAC) authorization is Enabled on Kubernetes Engine Clusters
+
+```sql
+select
+  name as user_name,
+  user_id as user_id
+from
+  alicloud_ram_user
+where
+  cs_user_permission <> '[]';
 ```

--- a/docs/tables/alicloud_ram_user.md
+++ b/docs/tables/alicloud_ram_user.md
@@ -80,7 +80,7 @@ where
   not mfa_enabled;
 ```
 
-### List all the users for whom role-based access control (RBAC) authorization is Enabled on Kubernetes Engine Clusters
+### List users with Container Service for Kubernetes role-based access control (RBAC) permissions
 
 ```sql
 select


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/alicloud_ram_user []

PRETEST: tests/alicloud_ram_user

TEST: tests/alicloud_ram_user
Running terraform
alicloud_ram_user.named_test_resource: Creating...
alicloud_ram_policy.named_test_resource: Creating...
alicloud_ram_group.named_test_resource: Creating...
alicloud_ram_group.named_test_resource: Creation complete after 2s [id=turbottest53057]
alicloud_ram_policy.named_test_resource: Creation complete after 2s [id=turbottest53057]
alicloud_ram_user.named_test_resource: Creation complete after 2s [id=258962023829371454]
alicloud_ram_group_membership.named_test_resource: Creating...
alicloud_ram_user_policy_attachment.attach: Creating...
alicloud_ram_user_policy_attachment.attach: Creation complete after 1s [id=user:turbottest53057:Custom:turbottest53057]
alicloud_ram_group_membership.named_test_resource: Creation complete after 1s [id=turbottest53057]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "5982111499156037"
membership_id = "turbottest53057"
policy_attachemnt_id = "turbottest53057"
resource_aka = "acs:ram::5982111499156037:user/turbottest53057"
resource_name = "turbottest53057"
user_id = "258962023829371454"

Running SQL query: test-get-query.sql
[
  {
    "account_id": "5982111499156037",
    "comments": "This is a test user.",
    "display_name": "turbottest53057",
    "email": "turbottest53057.test@yoyo.com",
    "mobile_phone": "86-18600008888",
    "name": "turbottest53057",
    "region": "global",
    "user_id": "258962023829371454"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "attached_group_name": "turbottest53057",
    "attached_policy_default_version": "v1",
    "attached_policy_name": "turbottest53057",
    "attached_policy_type": "Custom",
    "mfa_enabled": false,
    "name": "turbottest53057",
    "user_id": "258962023829371454"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "display_name": "turbottest53057",
    "name": "turbottest53057",
    "user_id": "258962023829371454"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "acs:ram::5982111499156037:user/turbottest53057"
    ],
    "name": "turbottest53057",
    "title": "turbottest53057"
  }
]
✔ PASSED

POSTTEST: tests/alicloud_ram_user

TEARDOWN: tests/alicloud_ram_user

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,cs_user_permission from alicloud_ram_user where name = 'sourav'
+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| name   | cs_user_permission                                                                                                                                                           |
+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| sourav | [{"is_owner":1,"parent_id":"5982111499156037","resource_id":"c93e9cf9bc798432b8b14d303684d8f23","resource_type":"cluster","role_name":"cluster-admin","role_type":"custom"}] |
+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
> select
  name as user_name,
  user_id as user_id
from
  alicloud_ram_user where cs_user_permission <> '[]'
+-----------+--------------------+
| user_name | user_id            |
+-----------+--------------------+
| sourav    | 228522213628100072 |
| lalit     | 256150713093470124 |
+-----------+--------------------+
```
</details>
