### PR TITLE
Add column to store bucket lifecycle configuration. Closes #188

### DIFF
--- a/alicloud-test/tests/alicloud_oss_bucket/test-list-expected.json
+++ b/alicloud-test/tests/alicloud_oss_bucket/test-list-expected.json
@@ -1,0 +1,59 @@
+[
+  {
+    "account_id": "{{ output.account_id.value }}",
+    "acl": "private",
+    "arn": "{{ output.bucket_arn.value }}",
+    "lifecycle_rules": [
+      {
+        "AbortMultipartUpload": null,
+        "Expiration": {
+          "CreatedBeforeDate": "",
+          "Date": "",
+          "Days": 365,
+          "ExpiredObjectDeleteMarker": null,
+          "XMLName": {
+            "Local": "Expiration",
+            "Space": ""
+          }
+        },
+        "ID": "rule-days",
+        "NonVersionExpiration": null,
+        "NonVersionTransition": null,
+        "NonVersionTransitions": null,
+        "Prefix": "path1/",
+        "Status": "Enabled",
+        "Tags": null,
+        "Transitions": null,
+        "XMLName": {
+          "Local": "Rule",
+          "Space": ""
+        }
+      }
+    ],
+    "location": "oss-{{ output.region.value }}",
+    "name": "{{ output.bucket_id.value }}",
+    "policy": {
+      "Statement": [
+        {
+          "Action": ["oss:PutObject", "oss:GetObject", "oss:DeleteBucket"],
+          "Effect": "Allow",
+          "Resource": ["acs:oss:*:*:*"]
+        }
+      ],
+      "Version": "1"
+    },
+    "region": "{{ output.region.value }}",
+    "server_side_encryption": {
+      "KMSDataEncryption": "",
+      "KMSMasterKeyID": "",
+      "SSEAlgorithm": "AES256"
+    },
+    "tags_src": [
+      {
+        "Key": "name",
+        "Value": "{{ output.bucket_id.value }}"
+      }
+    ],
+    "versioning": "Suspended"
+  }
+]

--- a/alicloud-test/tests/alicloud_oss_bucket/test-list-query.sql
+++ b/alicloud-test/tests/alicloud_oss_bucket/test-list-query.sql
@@ -1,0 +1,16 @@
+select
+  name,
+  arn,
+  location,
+  versioning,
+  acl,
+  server_side_encryption,
+  lifecycle_rules,
+  policy,
+  tags_src,
+  region,
+  account_id
+from
+  alicloud_oss_bucket
+where
+  name = '{{ output.bucket_id.value }}';

--- a/alicloud-test/tests/alicloud_oss_bucket/test-turbot-expected.json
+++ b/alicloud-test/tests/alicloud_oss_bucket/test-turbot-expected.json
@@ -1,0 +1,9 @@
+[
+  {
+    "akas": ["{{ output.bucket_arn.value }}"],
+    "tags": {
+      "name": "{{ output.bucket_id.value }}"
+    },
+    "title": "{{ output.bucket_id.value }}"
+  }
+]

--- a/alicloud-test/tests/alicloud_oss_bucket/test-turbot-query.sql
+++ b/alicloud-test/tests/alicloud_oss_bucket/test-turbot-query.sql
@@ -1,0 +1,8 @@
+select
+  title,
+  tags,
+  akas
+from
+  alicloud_oss_bucket
+where
+  name = '{{ output.bucket_id.value }}';

--- a/alicloud-test/tests/alicloud_oss_bucket/variables.tf
+++ b/alicloud-test/tests/alicloud_oss_bucket/variables.tf
@@ -1,0 +1,82 @@
+
+variable "resource_name" {
+  type        = string
+  default     = "turbot-test-20200125-create-update"
+  description = "Name of the resource used throughout the test."
+}
+
+variable "alicloud_region" {
+  type        = string
+  default     = "us-east-1"
+  description = "Alicloud region used for the test."
+}
+
+provider "alicloud" {
+  region = var.alicloud_region
+}
+
+data "alicloud_caller_identity" "current" {}
+
+data "null_data_source" "resource" {
+  inputs = {
+    scope = "acs:::${data.alicloud_caller_identity.current.account_id}"
+  }
+}
+
+resource "alicloud_oss_bucket" "named_test_resource" {
+  bucket = var.resource_name
+  acl    = "private"
+
+  # Policy
+  policy = <<POLICY
+  {"Statement":
+      [{"Action":
+          ["oss:PutObject", "oss:GetObject", "oss:DeleteBucket"],
+        "Effect":"Allow",
+        "Resource":
+            ["acs:oss:*:*:*"]}],
+   "Version":"1"}
+  POLICY
+
+  # Lifecycle Rules
+  lifecycle_rule {
+    id      = "rule-days"
+    prefix  = "path1/"
+    enabled = true
+
+    expiration {
+      days = 365
+    }
+  }
+
+  # Versioning
+  versioning {
+    status = "Suspended"
+  }
+
+  # SSE configuration
+  server_side_encryption_rule {
+    sse_algorithm = "AES256"
+  }
+
+  # Tags
+  tags = {
+    name = var.resource_name
+  }
+}
+
+output "bucket_id" {
+  value = alicloud_oss_bucket.named_test_resource.id
+}
+
+output "account_id" {
+  value = data.alicloud_caller_identity.current.account_id
+}
+
+output "region" {
+  value = var.alicloud_region
+}
+
+output "bucket_arn" {
+  value = "arn:acs:oss:::${alicloud_oss_bucket.named_test_resource.id}"
+}

--- a/alicloud/table_alicloud_oss_bucket.go
+++ b/alicloud/table_alicloud_oss_bucket.go
@@ -76,7 +76,7 @@ func tableAlicloudOssBucket(ctx context.Context) *plugin.Table {
 				Description: "The server-side encryption configuration for bucket",
 			},
 			{
-				Name:        "lifecycle_configuration",
+				Name:        "lifecycle_rules",
 				Type:        proto.ColumnType_JSON,
 				Description: "A list of lifecycle rules for a bucket.",
 				Hydrate:     getBucketLifecycle,

--- a/alicloud/table_alicloud_oss_bucket.go
+++ b/alicloud/table_alicloud_oss_bucket.go
@@ -76,6 +76,13 @@ func tableAlicloudOssBucket(ctx context.Context) *plugin.Table {
 				Description: "The server-side encryption configuration for bucket",
 			},
 			{
+				Name:        "lifecycle_configuration",
+				Type:        proto.ColumnType_JSON,
+				Description: "A list of lifecycle rules for a bucket.",
+				Hydrate:     getBucketLifecycle,
+				Transform:   transform.FromField("Rules"),
+			},
+			{
 				Name:        "logging",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getBucketLogging,
@@ -238,6 +245,26 @@ func getBucketInfo(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	response, err := client.GetBucketInfo(bucket.Name)
 	if err != nil {
 		logger.Error("getBucketInfo", "query_error", err, "bucket", bucket.Name)
+		return nil, err
+	}
+	return response, nil
+}
+
+func getBucketLifecycle(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getBucketLifecycle")
+
+	bucket := h.Item.(oss.BucketProperties)
+	client, err := OssService(ctx, d, removeSuffixFromLocation(bucket.Location))
+	if err != nil {
+		return nil, err
+	}
+
+	// Get bucket encryption
+	response, err := client.GetBucketLifecycle(bucket.Name)
+	if a, ok := err.(oss.ServiceError); ok {
+		if a.Code == "NoSuchLifecycle" {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return response, nil

--- a/docs/tables/alicloud_oss_bucket.md
+++ b/docs/tables/alicloud_oss_bucket.md
@@ -88,3 +88,18 @@ where
     or p = '*'
   );
 ```
+
+### List of buckets with no lifecycle policy
+
+```sql
+select
+  name,
+  arn,
+  region,
+  account_id,
+  lifecycle_rules
+from
+  alicloud_oss_bucket
+where
+  lifecycle_rules is null;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/alicloud_oss_bucket []

PRETEST: tests/alicloud_oss_bucket

TEST: tests/alicloud_oss_bucket
Running terraform
data.alicloud_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
alicloud_oss_bucket.named_test_resource: Creating...
alicloud_oss_bucket.named_test_resource: Still creating... [10s elapsed]
alicloud_oss_bucket.named_test_resource: Creation complete after 11s [id=turbottest39579]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = 1234567890123456
bucket_arn = arn:acs:oss:::turbottest39579
bucket_id = turbottest39579
region = us-east-1

Running SQL query: test-list-query.sql
[
  {
    "account_id": "1234567890123456",
    "acl": "private",
    "arn": "arn:acs:oss:::turbottest39579",
    "lifecycle_rules": [
      {
        "AbortMultipartUpload": null,
        "Expiration": {
          "CreatedBeforeDate": "",
          "Date": "",
          "Days": 365,
          "ExpiredObjectDeleteMarker": null,
          "XMLName": {
            "Local": "Expiration",
            "Space": ""
          }
        },
        "ID": "rule-days",
        "NonVersionExpiration": null,
        "NonVersionTransition": null,
        "NonVersionTransitions": null,
        "Prefix": "path1/",
        "Status": "Enabled",
        "Tags": null,
        "Transitions": null,
        "XMLName": {
          "Local": "Rule",
          "Space": ""
        }
      }
    ],
    "location": "oss-us-east-1",
    "name": "turbottest39579",
    "policy": {
      "Statement": [
        {
          "Action": [
            "oss:PutObject",
            "oss:GetObject",
            "oss:DeleteBucket"
          ],
          "Effect": "Allow",
          "Resource": [
            "acs:oss:*:*:*"
          ]
        }
      ],
      "Version": "1"
    },
    "region": "us-east-1",
    "server_side_encryption": {
      "KMSDataEncryption": "",
      "KMSMasterKeyID": "",
      "SSEAlgorithm": "AES256"
    },
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest39579"
      }
    ],
    "versioning": "Suspended"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:acs:oss:::turbottest39579"
    ],
    "tags": {
      "name": "turbottest39579"
    },
    "title": "turbottest39579"
  }
]
✔ PASSED

POSTTEST: tests/alicloud_oss_bucket

TEARDOWN: tests/alicloud_oss_bucket

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
### List of buckets with no lifecycle policy

```sql
select
  name,
  arn,
  region,
  account_id,
  lifecycle_rules
from
  alicloud_oss_bucket
where
  lifecycle_rules is null;
```
```
+-----------------+-------------------------------+-----------+------------------+-----------------+
| name            | arn                           | region    | account_id       | lifecycle_rules |
+-----------------+-------------------------------+-----------+------------------+-----------------+
| nw-test-3       | arn:acs:oss:::nw-test-3       | us-east-1 | 1234567890123456 | <null>          |
| nw-test-1       | arn:acs:oss:::nw-test-1       | us-east-1 | 1234567890123456 | <null>          |
| turbottest96253 | arn:acs:oss:::turbottest96253 | us-east-1 | 1234567890123456 | <null>          |
| cis-test-mar12  | arn:acs:oss:::cis-test-mar12  | us-east-1 | 1234567890123456 | <null>          |
| turbottest2670  | arn:acs:oss:::turbottest2670  | us-east-1 | 1234567890123456 | <null>          |
| canonical-test  | arn:acs:oss:::canonical-test  | us-east-1 | 1234567890123456 | <null>          |
| cis-test2       | arn:acs:oss:::cis-test2       | us-east-1 | 1234567890123456 | <null>          |
+-----------------+-------------------------------+-----------+------------------+-----------------+
```
</details>
