### PR TITLE
Update table alicloud_action_trail to include shadow trails. Closes #206

### DIFF
--- a/alicloud-test/tests/alicloud_action_trail/test-list-expected.json
+++ b/alicloud-test/tests/alicloud_action_trail/test-list-expected.json
@@ -1,7 +1,8 @@
 [
-	{
-		"event_rw": "All",
-		"name": "{{ resourceName }}",
-		"trail_region": "All"
-	}
+  {
+    "event_rw": "All",
+    "home_region": "{{ output.region_name.value }}",
+    "name": "{{ resourceName }}",
+    "trail_region": "All"
+  }
 ]

--- a/alicloud-test/tests/alicloud_action_trail/test-list-query.sql
+++ b/alicloud-test/tests/alicloud_action_trail/test-list-query.sql
@@ -1,3 +1,3 @@
-select name, trail_region,event_rw
+select name, trail_region,event_rw, home_region
 from alicloud_action_trail
-where akas::text = '["{{ output.resource_aka.value }}"]'
+where akas::text = '["{{ output.resource_aka.value }}"]' and region = '{{ output.region_name.value }}'

--- a/alicloud-test/tests/alicloud_action_trail/variables.tf
+++ b/alicloud-test/tests/alicloud_action_trail/variables.tf
@@ -23,9 +23,10 @@ data "null_data_source" "resource" {
 }
 
 resource "alicloud_oss_bucket" "named_test_resource" {
-  bucket = var.resource_name
-  acl    = "private"
-  policy = <<POLICY
+  bucket        = var.resource_name
+  acl           = "private"
+  force_destroy = true
+  policy        = <<POLICY
   {"Statement":
       [{"Action":
           ["oss:PutObject", "oss:GetObject", "oss:DeleteBucket"],
@@ -52,7 +53,7 @@ output "resource_name" {
   value = var.resource_name
 }
 
-output "region_name"{
+output "region_name" {
   value = var.alicloud_region
 }
 

--- a/alicloud/table_alicloud_action_trail.go
+++ b/alicloud/table_alicloud_action_trail.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/actiontrail"
 
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -127,7 +128,7 @@ func tableAlicloudActionTrail(ctx context.Context) *plugin.Table {
 				Name:        "region",
 				Description: ColumnDescriptionRegion,
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("HomeRegion"),
+				Transform:   transform.From(actionTrailRegion),
 			},
 			{
 				Name:        "account_id",
@@ -153,6 +154,7 @@ func listActionTrails(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 	}
 	request := actiontrail.CreateDescribeTrailsRequest()
 	request.Scheme = "https"
+	request.IncludeShadowTrails = requests.NewBoolean(true)
 
 	response, err := client.DescribeTrails(request)
 	if err != nil {
@@ -211,4 +213,12 @@ func getActionTrailAka(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	akas := []string{"acs:actiontrail:" + data.HomeRegion + ":" + accountID + ":actiontrail/" + data.Name}
 
 	return akas, nil
+}
+
+//// TRANSFORM FUNCTIONS
+
+func actionTrailRegion(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
+
+	return region, nil
 }

--- a/docs/tables/alicloud_action_trail.md
+++ b/docs/tables/alicloud_action_trail.md
@@ -46,3 +46,17 @@ from
 where
   is_organization_trail;
 ```
+
+### List shadow trails
+
+```sql
+select
+  name,
+  region,
+  home_region
+from
+  alicloud_action_trail
+where
+  trail_region = 'All'
+  and home_region <> region;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/alicloud_action_trail []

PRETEST: tests/alicloud_action_trail

TEST: tests/alicloud_action_trail
Running terraform
data.alicloud_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
alicloud_oss_bucket.named_test_resource: Creating...
alicloud_oss_bucket.named_test_resource: Creation complete after 9s [id=turbottest14221]
alicloud_actiontrail_trail.named_test_resource: Creating...
alicloud_actiontrail_trail.named_test_resource: Still creating... [10s elapsed]
alicloud_actiontrail_trail.named_test_resource: Still creating... [20s elapsed]
alicloud_actiontrail_trail.named_test_resource: Creation complete after 25s [id=turbottest14221]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

account_id = 5982111499156037
region_name = us-east-1
resource_aka = acs:actiontrail:us-east-1:5982111499156037:actiontrail/turbottest14221
resource_name = turbottest14221

Running SQL query: test-get-query.sql
[
  {
    "name": "turbottest14221",
    "oss_bucket_name": "turbottest14221",
    "region": "us-east-1",
    "status": "Enable",
    "trail_region": "All"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "event_rw": "All",
    "home_region": "us-east-1",
    "name": "turbottest14221",
    "trail_region": "All"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "acs:actiontrail:us-east-1:5982111499156037:actiontrail/turbottest14221"
    ],
    "name": "turbottest14221",
    "title": "turbottest14221"
  }
]
✔ PASSED

POSTTEST: tests/alicloud_action_trail

TEARDOWN: tests/alicloud_action_trail

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
### List shadow trails

```sql
select
  name,
  region,
  home_region
from
  alicloud_action_trail
where
  trail_region = 'All'
  and home_region <> region;
```
```
+-----------------+-------------+-------------+
| name            | region      | home_region |
+-----------------+-------------+-------------+
| turbottest60503 | ap-south-1  | us-east-1   |
| testthrifty01   | cn-hangzhou | ap-south-1  |
| turbottest60503 | cn-hangzhou | us-east-1   |
| test56          | cn-hangzhou | ap-south-1  |
| test56          | us-west-1   | ap-south-1  |
| turbottest60503 | us-west-1   | us-east-1   |
| testthrifty01   | us-west-1   | ap-south-1  |
| test56          | us-east-1   | ap-south-1  |
| testthrifty01   | us-east-1   | ap-south-1  |
+-----------------+-------------+-------------+
```
</details>
