### PR TITLE
Add retry mechanism for alicloud_rds_instance table. Closes #219

### DIFF
--- a/alicloud-test/tests/alicloud_rds_instance/variables.tf
+++ b/alicloud-test/tests/alicloud_rds_instance/variables.tf
@@ -32,15 +32,15 @@ data "alicloud_zones" "resource" {
 
 
 resource "alicloud_vpc" "named_test_resource" {
-  name       = var.resource_name
+  vpc_name   = var.resource_name
   cidr_block = "172.16.0.0/16"
 }
 
 resource "alicloud_vswitch" "named_test_resource" {
-  vpc_id            = alicloud_vpc.named_test_resource.id
-  availability_zone = data.alicloud_zones.resource.zones[0].id
-  cidr_block        = "172.16.0.0/24"
-  name              = var.resource_name
+  vpc_id       = alicloud_vpc.named_test_resource.id
+  zone_id      = data.alicloud_zones.resource.zones[0].id
+  cidr_block   = "172.16.0.0/24"
+  vswitch_name = var.resource_name
 }
 
 resource "alicloud_db_instance" "named_test_resource" {

--- a/alicloud/monitoring_metric.go
+++ b/alicloud/monitoring_metric.go
@@ -136,7 +136,7 @@ func listCMMetricStatistics(ctx context.Context, d *plugin.QueryData, granularit
 		return nil, err
 	}
 
-	err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
+	err = retry.Do(ctx, retry.WithMaxRetries(5, b), func(ctx context.Context) error {
 		var err error
 		stats, err = client.DescribeMetricList(request)
 		if err != nil {

--- a/alicloud/monitoring_metric.go
+++ b/alicloud/monitoring_metric.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cms"
+	"github.com/sethvargo/go-retry"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 )
@@ -127,8 +129,27 @@ func listCMMetricStatistics(ctx context.Context, d *plugin.QueryData, granularit
 	request.Namespace = namespace
 	request.Period = getCMPeriodForGranularity(granularity)
 	request.Dimensions = metricDimension
+	var stats *cms.DescribeMetricListResponse
 
-	stats, err := client.DescribeMetricList(request)
+	b, err := retry.NewFibonacci(100 * time.Millisecond)
+	if err != nil {
+		return nil, err
+	}
+
+	err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
+		var err error
+		stats, err = client.DescribeMetricList(request)
+		if err != nil {
+			if serverErr, ok := err.(*errors.ServerError); ok {
+				if serverErr.ErrorCode() == "Throttling" {
+					return retry.RetryableError(err)
+				}
+				return err
+			}
+		}
+		return nil
+	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/alicloud/table_alicloud_rds_instance.go
+++ b/alicloud/table_alicloud_rds_instance.go
@@ -613,7 +613,7 @@ func getRdsInstance(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 		return nil, err
 	}
 
-	err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
+	err = retry.Do(ctx, retry.WithMaxRetries(5, b), func(ctx context.Context) error {
 		var err error
 		response, err = client.DescribeDBInstanceAttribute(request)
 		if err != nil {
@@ -731,7 +731,6 @@ func getSSLDetails(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		return "Enabled", nil
 	}
 	return "Disabled", nil
-
 }
 
 func getRdsInstanceParameters(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -755,7 +754,6 @@ func getRdsInstanceParameters(ctx context.Context, d *plugin.QueryData, h *plugi
 		return nil, err
 	}
 	return response, nil
-
 }
 
 func getRdsTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/alicloud/table_alicloud_rds_instance.go
+++ b/alicloud/table_alicloud_rds_instance.go
@@ -24,7 +24,7 @@ func tableAlicloudRdsInstance(ctx context.Context) *plugin.Table {
 			Hydrate: listRdsInstances,
 		},
 		Get: &plugin.GetConfig{
-			KeyColumns:        plugin.SingleColumn("db_instance_id"),
+			KeyColumns:        plugin.AllColumns([]string{"db_instance_id", "region"}),
 			ShouldIgnoreError: isNotFoundError([]string{"InvalidDBInstanceId.NotFound"}),
 			Hydrate:           getRdsInstance,
 		},
@@ -583,10 +583,10 @@ func listRdsInstances(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 //// HYDRATE FUNCTIONS
 
 func getRdsInstance(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	region := d.KeyColumnQualString(matrixKeyRegion)
+	regionMatrix := d.KeyColumnQualString(matrixKeyRegion)
 
 	// Create service connection
-	client, err := RDSService(ctx, d, region)
+	client, err := RDSService(ctx, d, regionMatrix)
 	if err != nil {
 		plugin.Logger(ctx).Error("getRdsInstance", "connection_error", err)
 		return nil, err
@@ -597,6 +597,10 @@ func getRdsInstance(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 		id = databaseID(h.Item)
 	} else {
 		id = d.KeyColumnQuals["db_instance_id"].GetStringValue()
+		region := d.KeyColumnQuals["region"].GetStringValue()
+		if region != regionMatrix {
+			return nil, nil
+		}
 	}
 
 	request := rds.CreateDescribeDBInstanceAttributeRequest()


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/alicloud_rds_instance []

PRETEST: tests/alicloud_rds_instance

TEST: tests/alicloud_rds_instance
Running terraform
data.alicloud_zones.resource: Refreshing state...
data.alicloud_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
alicloud_vpc.named_test_resource: Creating...
alicloud_vpc.named_test_resource: Creation complete after 7s [id=vpc-0xijelr5qo57vsi7pn9uv]
alicloud_vswitch.named_test_resource: Creating...
alicloud_vswitch.named_test_resource: Creation complete after 7s [id=vsw-0xi6qzr375v1wm39nerha]
alicloud_db_instance.named_test_resource: Creating...
alicloud_db_instance.named_test_resource: Still creating... [10s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [20s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [30s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [40s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [50s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [1m0s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [1m10s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [1m20s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [1m30s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [1m40s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [1m50s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [2m0s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [2m10s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [2m20s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [2m30s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [2m40s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [2m50s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [3m0s elapsed]
alicloud_db_instance.named_test_resource: Still creating... [3m10s elapsed]
alicloud_db_instance.named_test_resource: Creation complete after 3m20s [id=rm-7go12gafyx862szdt]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

db_instance_id = rm-7go12gafyx862szdt
port = 3306
resource_aka = arn:acs:rds:us-east-1:1234567890123456:instance/rm-7go12gafyx862szdt
resource_name = turbottest94532
zone_id = us-east-1a

Running SQL query: test-get-query.sql
[
  {
    "db_instance_id": "rm-7go12gafyx862szdt",
    "db_instance_type": "Primary",
    "engine": "MySQL",
    "engine_version": "5.7"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "arn": "arn:acs:rds:us-east-1:1234567890123456:instance/rm-7go12gafyx862szdt",
    "port": "3306"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "db_instance_storage": 30,
    "zone_id": "us-east-1a"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:acs:rds:us-east-1:1234567890123456:instance/rm-7go12gafyx862szdt"
    ],
    "title": "rm-7go12gafyx862szdt"
  }
]
✔ PASSED

POSTTEST: tests/alicloud_rds_instance

TEARDOWN: tests/alicloud_rds_instance

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
