### PR TITLE
select * from alicloud_ram_user results in error. closes #239

### DIFF
--- a/alicloud/table_alicloud_ram_user.go
+++ b/alicloud/table_alicloud_ram_user.go
@@ -332,8 +332,6 @@ func getCsUserPermissions(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	request.Version = "2015-12-15"
 	request.PathPattern = "/permissions/users/" + data.UserId
 	request.Headers["Content-Type"] = "application/json"
-	body := `{}`
-	request.Content = []byte(body)
 
 	response, err := client.ProcessCommonRequest(request)
 	if serverErr, ok := err.(*errors.ServerError); ok {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/alicloud_ram_user []

PRETEST: tests/alicloud_ram_user

TEST: tests/alicloud_ram_user
Running terraform
alicloud_ram_user.named_test_resource: Creating...
alicloud_ram_policy.named_test_resource: Creating...
alicloud_ram_group.named_test_resource: Creating...
alicloud_ram_group.named_test_resource: Creation complete after 2s [id=turbottest53057]
alicloud_ram_policy.named_test_resource: Creation complete after 2s [id=turbottest53057]
alicloud_ram_user.named_test_resource: Creation complete after 2s [id=258962023829371454]
alicloud_ram_group_membership.named_test_resource: Creating...
alicloud_ram_user_policy_attachment.attach: Creating...
alicloud_ram_user_policy_attachment.attach: Creation complete after 1s [id=user:turbottest53057:Custom:turbottest53057]
alicloud_ram_group_membership.named_test_resource: Creation complete after 1s [id=turbottest53057]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "5982111499156037"
membership_id = "turbottest53057"
policy_attachemnt_id = "turbottest53057"
resource_aka = "acs:ram::5982111499156037:user/turbottest53057"
resource_name = "turbottest53057"
user_id = "258962023829371454"

Running SQL query: test-get-query.sql
[
  {
    "account_id": "5982111499156037",
    "comments": "This is a test user.",
    "display_name": "turbottest53057",
    "email": "turbottest53057.test@yoyo.com",
    "mobile_phone": "86-18600008888",
    "name": "turbottest53057",
    "region": "global",
    "user_id": "258962023829371454"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "attached_group_name": "turbottest53057",
    "attached_policy_default_version": "v1",
    "attached_policy_name": "turbottest53057",
    "attached_policy_type": "Custom",
    "mfa_enabled": false,
    "name": "turbottest53057",
    "user_id": "258962023829371454"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "display_name": "turbottest53057",
    "name": "turbottest53057",
    "user_id": "258962023829371454"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "acs:ram::5982111499156037:user/turbottest53057"
    ],
    "name": "turbottest53057",
    "title": "turbottest53057"
  }
]
✔ PASSED

POSTTEST: tests/alicloud_ram_user

TEARDOWN: tests/alicloud_ram_user

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select name, display_name, cs_user_permissions from alicloud_ram_user
+--------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| name         | display_name     | cs_user_permissions                                                                                                                                                     
+--------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| cisuser      | CIS User         | []                                                                                                                                                                      
| khushboo     | khushboo         | []                                                                                                                                                                      
| oscar        | Oscar            | []                                                                                                                                                                      
| raj          | Rajesh Mohanty   | []                                                                                                                                                                      
| subhajit     | Subhajit         | []                                                                                                                                                                      
| david        | David Boeke      | []                                                                                                                                                                      
| lalit        | Lalit            | []                                                                                                                                                                      
| cody         | cody             | []                                                                                                                                                                      
| michael      | Michael          | []                                                                                                                                                                      
| dwight       | Dwight           | []                                                                                                                                                                      
| jim          | Jim              | []                                                                                                                                                                      
| kevin        | Kevin            | []                                                                                                                                                                      
| sourav       | Sourav           | [{"is_owner":1,"parent_id":"5982111499156037","resource_id":"c7fffb4d3211c47b5a8e4987ce731b8fe","resource_type":"cluster","role_name":"cluster-admin","role_type":"custo
| nw-steampipe | Nathan Wallace   | []                                                                                                                                                                      
| pam          | Pam              | []                                                                                                                                                                      
| john         | John             | []                                                                                                                                                                      
| ved          | Ved              | []                                                                                                                                                                      
| partha       | Partha           | [{"parent_id":"0","resource_id":"c7fffb4d3211c47b5a8e4987ce731b8fe","resource_type":"cluster","role_name":"","role_type":"admin"}]                                      
| abhinash     | Abhinash Khuntia | []                                                                                                                                                                      
+--------------+------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
</details>
