### PR TITLE
Recompiled `alicloud_ecs_instance_metric_cpu_utilization_hourly` table with steampipe-plugin-sdk v2.1.1

### DIFF
--- a/alicloud/table_alicloud_ecs_instance_metric_cpu_utilization_hourly.go
+++ b/alicloud/table_alicloud_ecs_instance_metric_cpu_utilization_hourly.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
-	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v2/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin/transform"
 )
 
 //// TABLE DEFINITION


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select
  instance_id,
  timestamp,
  minimum,
  maximum,
  average
from
  alicloud_ecs_instance_metric_cpu_utilization_hourly
order by
  instance_id,
  timestamp;
+------------------------+---------------------------+---------+---------+---------+
| instance_id            | timestamp                 | minimum | maximum | average |
+------------------------+---------------------------+---------+---------+---------+
| i-0xi329y5rabrp23dm2ai | 2022-03-24T15:30:00+05:30 | 2.947   | 15.437  | 5.463   |
| i-0xi329y5rabrp23dm2ai | 2022-03-24T16:30:00+05:30 | 4.562   | 5       | 4.812   |
| i-0xi329y5rabrp23dm2ai | 2022-03-24T17:30:00+05:30 | 4.525   | 5.475   | 4.873   |
| i-0xi329y5rabrp23dm2ai | 2022-03-24T18:30:00+05:30 | 4.55    | 5.256   | 4.847   
```
</details>
