### PR TITLE
Add column ipv6_cidr_blocks to alicloud_vpc table closes #258

### DIFF
--- a/alicloud/table_alicloud_vpc.go
+++ b/alicloud/table_alicloud_vpc.go
@@ -148,7 +148,7 @@ func tableAlicloudVpc(ctx context.Context) *plugin.Table {
 				Name:        "ipv6_cidr_blocks",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Ipv6CidrBlocks.Ipv6CidrBlock"),
-				Description: "The IPv6 CIDR block of the VPC.",
+				Description: "The IPv6 CIDR blocks of the VPC.",
 			},
 			{
 				Name:        "vswitch_ids",

--- a/alicloud/table_alicloud_vpc.go
+++ b/alicloud/table_alicloud_vpc.go
@@ -145,6 +145,12 @@ func tableAlicloudVpc(ctx context.Context) *plugin.Table {
 				Description: "The list of resources in the VPC.",
 			},
 			{
+				Name:        "ipv6_cidr_blocks",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Ipv6CidrBlocks.Ipv6CidrBlock"),
+				Description: "The IPv6 CIDR block of the VPC.",
+			},
+			{
 				Name:        "vswitch_ids",
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("VSwitchIds.VSwitchId"),


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, ipv6_cidr_blocks from alicloud_vpc
+------------------+---------------------------------------------------------------+
| name             | ipv6_cidr_blocks                                              |
+------------------+---------------------------------------------------------------+
|                  | <null>                                                        |
|                  | <null>                                                        |
| tes1233456       | <null>                                                        |
| test3            | <null>                                                        |
| turbottest57082  | <null>                                                        |
|                  | <null>                                                        |
| turbottest76546  | <null>                                                        |
| vpc-for-instance | [{"Ipv6CidrBlock":"240b:4002:101:2d00::/56","Ipv6Isp":"BGP"}] |
+------------------+---------------------------------------------------------------+
```
</details>
