### PR TITLE
Fix incosistent table name of alicloud_vpc_vswitch table

### DIFF
--- a/alicloud/table_alicloud_vpc_vswitch.go
+++ b/alicloud/table_alicloud_vpc_vswitch.go
@@ -16,7 +16,7 @@ import (
 
 func tableAlicloudVpcVSwitch(ctx context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "alicloud_vswitch",
+		Name:        "alicloud_vpc_vswitch",
 		Description: "VSwitches to divide the VPC network into one or more subnets.",
 		List: &plugin.ListConfig{
 			Hydrate: listVSwitch,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
