### PR TITLE
Fix table alicloud_cs_kubernetes_cluster_node for failed to populate column 'cluster_id' closes #282

### DIFF
--- a/alicloud/table_alicloud_cs_kubernetes_cluster_node.go
+++ b/alicloud/table_alicloud_cs_kubernetes_cluster_node.go
@@ -36,7 +36,6 @@ func tableAlicloudCsKubernetesClusterNode(ctx context.Context) *plugin.Table {
 				Name:        "cluster_id",
 				Description: "The ID of the cluster that the node pool belongs to.",
 				Type:        proto.ColumnType_STRING,
-				// Transform:   transform.From(clusterIdFromInstanceName),
 			},
 			{
 				Name:        "state",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
> select * from alicloud_cs_kubernetes_cluster_node
+----------------------+-----------------------------------+---------+---------------------------+--------------+-------------+----------------+--------+-----------------------
| node_name            | cluster_id                        | state   | creation_time             | expired_time | node_status | is_aliyun_node | source | instance_id           
+----------------------+-----------------------------------+---------+---------------------------+--------------+-------------+----------------+--------+-----------------------
| us-east-1.10.1.1.245 | c2c961c1610f5431c91615ace165c5575 | running | 2022-08-29T14:09:27+05:30 | <null>       | Ready       | true           | <null> | i-0xi15sjlg3cc6vl32y3x
| us-east-1.10.1.1.244 | c2c961c1610f5431c91615ace165c5575 | running | 2022-08-29T14:09:18+05:30 | <null>       | Ready       | true           | <null> | i-0xi15sjlg3cc6vl32y3y
| us-east-1.10.1.1.246 | c2c961c1610f5431c91615ace165c5575 | running | 2022-08-29T14:09:25+05:30 | <null>       | Ready       | true           | <null> | i-0xi15sjlg3cc6vl32y3w
+----------------------+-----------------------------------+---------+---------------------------+--------------+-------------+----------------+--------+-----------------------

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
No env file present for the current environment:  staging
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/alicloud_cs_kubernetes_cluster_node []

PRETEST: tests/alicloud_cs_kubernetes_cluster_node

TEST: tests/alicloud_cs_kubernetes_cluster_node
Running terraform
data.alicloud_caller_identity.current: Reading...
data.alicloud_caller_identity.current: Read complete after 2s [id=295372922530649815]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # alicloud_cs_managed_kubernetes.named_test_resource[0] will be created
  + resource "alicloud_cs_managed_kubernetes" "named_test_resource" {
      + availability_zone            = (known after apply)
      + certificate_authority        = (known after apply)
      + cluster_domain               = "cluster.local"
      + cluster_spec                 = "ack.standard"
      + connections                  = (known after apply)
      + deletion_protection          = false
      + id                           = (known after apply)
      + install_cloud_monitor        = true
      + is_enterprise_security_group = true
      + load_balancer_spec           = "slb.s1.small"
      + name                         = "turbottest18430"
      + name_prefix                  = "Terraform-Creation"
      + nat_gateway_id               = (known after apply)
      + new_nat_gateway              = true
      + node_cidr_mask               = 24
      + node_port_range              = (known after apply)
      + os_type                      = "Linux"
      + password                     = (sensitive value)
      + platform                     = (known after apply)
      + pod_cidr                     = "172.20.0.0/16"
      + proxy_mode                   = "ipvs"
      + resource_group_id            = (known after apply)
      + security_group_id            = (known after apply)
      + service_cidr                 = "172.21.0.0/20"
      + slb_id                       = (known after apply)
      + slb_internet                 = (known after apply)
      + slb_internet_enabled         = true
      + slb_intranet                 = (known after apply)
      + version                      = (known after apply)
      + vpc_id                       = (known after apply)
      + worker_auto_renew_period     = (known after apply)
      + worker_disk_size             = (known after apply)
      + worker_instance_types        = [
          + "ecs.c5.large",
        ]
      + worker_nodes                 = (known after apply)
      + worker_number                = 3
      + worker_period                = (known after apply)
      + worker_period_unit           = (known after apply)
      + worker_ram_role_name         = (known after apply)
      + worker_vswitch_ids           = (known after apply)

      + maintenance_window {
          + duration         = (known after apply)
          + enable           = (known after apply)
          + maintenance_time = (known after apply)
          + weekly_period    = (known after apply)
        }
    }

  # alicloud_vpc.named_test_resource will be created
  + resource "alicloud_vpc" "named_test_resource" {
      + cidr_block        = "10.1.0.0/21"
      + id                = (known after apply)
      + ipv6_cidr_block   = (known after apply)
      + name              = (known after apply)
      + resource_group_id = (known after apply)
      + route_table_id    = (known after apply)
      + router_id         = (known after apply)
      + router_table_id   = (known after apply)
      + status            = (known after apply)
      + vpc_name          = "turbottest18430"
    }

  # alicloud_vswitch.named_test_resource will be created
  + resource "alicloud_vswitch" "named_test_resource" {
      + availability_zone = (known after apply)
      + cidr_block        = "10.1.1.0/24"
      + id                = (known after apply)
      + name              = (known after apply)
      + status            = (known after apply)
      + vpc_id            = (known after apply)
      + vswitch_name      = (known after apply)
      + zone_id           = "us-east-1b"
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + cluster_id    = (known after apply)
  + instance_id   = (known after apply)
  + instance_name = (known after apply)
  + ip_address    = (known after apply)
  + region        = "us-east-1"
  + resource_aka  = "acs:cs:us-east-1:5982111499156037:node/turbottest18430"
  + resource_name = "turbottest18430"
alicloud_vpc.named_test_resource: Creating...
alicloud_vpc.named_test_resource: Creation complete after 7s [id=vpc-0xinhold2sy7sw1tcpgzk]
alicloud_vswitch.named_test_resource: Creating...
alicloud_vswitch.named_test_resource: Creation complete after 8s [id=vsw-0xiuoz6xa8chavw9w0t1i]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Creating...
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [1m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [2m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [3m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [4m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [5m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [6m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m0s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m10s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m20s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m30s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m40s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [7m50s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m1s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m11s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m21s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m31s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m41s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [8m51s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [9m1s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [9m11s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [9m21s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [9m31s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [9m41s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [9m51s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [10m1s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [10m11s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [10m21s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [10m31s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Still creating... [10m41s elapsed]
alicloud_cs_managed_kubernetes.named_test_resource[0]: Creation complete after 10m42s [id=c1f36109559f64d9aadb7f835f67e94d8]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 19, in data "null_data_source" "resource":
  19: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: "password": [DEPRECATED] Field 'password' has been deprecated from provider version 1.177.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes, by using field 'password' to replace it

  with alicloud_cs_managed_kubernetes.named_test_resource,
  on variables.tf line 38, in resource "alicloud_cs_managed_kubernetes" "named_test_resource":
  38: resource "alicloud_cs_managed_kubernetes" "named_test_resource" {

(and 2 more similar warnings elsewhere)

Warning: "worker_number": [DEPRECATED] Field 'worker_number' has been deprecated from provider version 1.177.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes., by using field 'desired_size' to replace it.

  with alicloud_cs_managed_kubernetes.named_test_resource,
  on variables.tf line 38, in resource "alicloud_cs_managed_kubernetes" "named_test_resource":
  38: resource "alicloud_cs_managed_kubernetes" "named_test_resource" {

(and 2 more similar warnings elsewhere)

Warning: "worker_instance_types": [DEPRECATED] Field 'worker_instance_types' has been deprecated from provider version 1.177.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes, by using field 'instance_types' to replace it.

  with alicloud_cs_managed_kubernetes.named_test_resource,
  on variables.tf line 38, in resource "alicloud_cs_managed_kubernetes" "named_test_resource":
  38: resource "alicloud_cs_managed_kubernetes" "named_test_resource" {

(and 2 more similar warnings elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

cluster_id = "c1f36109559f64d9aadb7f835f67e94d8"
instance_id = "i-0xi15sjlg3ccabw16fcb"
ip_address = "10.1.1.105"
region = "us-east-1"
resource_aka = "acs:cs:us-east-1:5982111499156037:node/turbottest18430"
resource_name = "turbottest18430"

Running SQL query: test-get-query.sql
[
  {
    "cluster_id": "c1f36109559f64d9aadb7f835f67e94d8",
    "instance_id": "i-0xi15sjlg3ccabw16fcb"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "cluster_id": "c1f36109559f64d9aadb7f835f67e94d8",
    "instance_id": "i-0xi15sjlg3ccabw16fcb"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

TEARDOWN: tests/alicloud_cs_kubernetes_cluster_node

SUMMARY:

1/1 passed.
```
</details>
