### PR TITLE
Error in get call for table alicloud_ecs_image closes #314

### DIFF
--- a/alicloud/table_alicloud_ecs_image.go
+++ b/alicloud/table_alicloud_ecs_image.go
@@ -19,10 +19,11 @@ func tableAlicloudEcsImage(ctx context.Context) *plugin.Table {
 		Name:        "alicloud_ecs_image",
 		Description: "AliCloud ECS Image.",
 		List: &plugin.ListConfig{
-			Hydrate: listEcsImages,
+			Hydrate:    listEcsImages,
 		},
 		Get: &plugin.GetConfig{
-			KeyColumns: plugin.SingleColumn("image_id"),
+			// We must include both image_id and region in the where clause else we will receive numerous rows. Which causes Error: get call returned 2 results - the key column is not globally unique (SQLSTATE HV000)
+			KeyColumns: plugin.AllColumns([]string{"image_id", "region"}),
 			Hydrate:    getEcsImage,
 		},
 		GetMatrixItemFunc: BuildRegionList,
@@ -226,10 +227,14 @@ func listEcsImages(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 		plugin.Logger(ctx).Error("alicloud_ecs_image.listEcsImages", "connection_error", err)
 		return nil, err
 	}
+
+	// regionName := d.KeyColumnQuals["region"].GetStringValue()
+
 	request := ecs.CreateDescribeImagesRequest()
 	request.Scheme = "https"
 	request.PageSize = requests.NewInteger(50)
 	request.PageNumber = requests.NewInteger(1)
+	// request.RegionId = regionName
 
 	count := 0
 	for {
@@ -254,7 +259,6 @@ func listEcsImages(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 //// HYDRATE FUNCTIONS
 
 func getEcsImage(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getEcsImage")
 	// Create service connection
 	client, err := ECSService(ctx, d)
 	if err != nil {
@@ -262,17 +266,18 @@ func getEcsImage(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 		return nil, err
 	}
 
-	var id string
-	if h.Item != nil {
-		data := h.Item.(ecs.Image)
-		id = data.ImageId
-	} else {
-		id = d.KeyColumnQuals["image_id"].GetStringValue()
+	id := d.KeyColumnQuals["image_id"].GetStringValue()
+	regionName := d.KeyColumnQuals["region"].GetStringValue()
+
+	// Handle empty name or region
+	if id == "" || regionName == "" {
+		return nil, nil
 	}
 
 	request := ecs.CreateDescribeImagesRequest()
 	request.Scheme = "https"
 	request.ImageId = id
+	request.RegionId = regionName
 
 	response, err := client.DescribeImages(request)
 	if serverErr, ok := err.(*errors.ServerError); ok {

--- a/alicloud/table_alicloud_ecs_image.go
+++ b/alicloud/table_alicloud_ecs_image.go
@@ -19,7 +19,7 @@ func tableAlicloudEcsImage(ctx context.Context) *plugin.Table {
 		Name:        "alicloud_ecs_image",
 		Description: "AliCloud ECS Image.",
 		List: &plugin.ListConfig{
-			Hydrate:    listEcsImages,
+			Hydrate: listEcsImages,
 		},
 		Get: &plugin.GetConfig{
 			// We must include both image_id and region in the where clause else we will receive numerous rows. Which causes Error: get call returned 2 results - the key column is not globally unique (SQLSTATE HV000)

--- a/alicloud/table_alicloud_ecs_image.go
+++ b/alicloud/table_alicloud_ecs_image.go
@@ -20,6 +20,12 @@ func tableAlicloudEcsImage(ctx context.Context) *plugin.Table {
 		Description: "AliCloud ECS Image.",
 		List: &plugin.ListConfig{
 			Hydrate: listEcsImages,
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "image_id",
+					Require: plugin.Optional,
+				},
+			},
 		},
 		Get: &plugin.GetConfig{
 			// We must include both image_id and region in the where clause else we will receive numerous rows. Which causes Error: get call returned 2 results - the key column is not globally unique (SQLSTATE HV000)
@@ -228,13 +234,14 @@ func listEcsImages(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 		return nil, err
 	}
 
-	// regionName := d.KeyColumnQuals["region"].GetStringValue()
-
 	request := ecs.CreateDescribeImagesRequest()
 	request.Scheme = "https"
 	request.PageSize = requests.NewInteger(50)
 	request.PageNumber = requests.NewInteger(1)
-	// request.RegionId = regionName
+	imageId := d.KeyColumnQualString("image_id")
+	if imageId != "" {
+		request.ImageId = imageId
+	}
 
 	count := 0
 	for {

--- a/docs/tables/alicloud_ecs_image.md
+++ b/docs/tables/alicloud_ecs_image.md
@@ -2,6 +2,8 @@
 
 An ECS image stores information that is required to create an ECS instance. An image works as a copy that stores data from one or more disks. An ECS instance image may store data from a system disk or from both system and data disks.
 
+To query a specific ECS image you need to pass `image_id` and `region` in the where clause (`where iamge_id='' and region=''`).
+
 ## Examples
 
 ### Image basic info
@@ -109,4 +111,22 @@ from
 where
   instance.image_id = image.image_id
   and image.creation_time <= (current_date - interval '90' day)
+```
+
+### Get a particular image details
+
+```sql
+select
+  name,
+  image_id,
+  arn,
+  size,
+  status,
+  usage
+from
+  alicloud_ecs_image
+where
+  image_id = 'centos_7_9_x64_20G_alibase_20221129.vhd'
+and
+  region = 'us-east-1';
 ```

--- a/docs/tables/alicloud_ecs_image.md
+++ b/docs/tables/alicloud_ecs_image.md
@@ -2,7 +2,7 @@
 
 An ECS image stores information that is required to create an ECS instance. An image works as a copy that stores data from one or more disks. An ECS instance image may store data from a system disk or from both system and data disks.
 
-To query a specific ECS image you need to pass `image_id` and `region` in the where clause (`where iamge_id='' and region=''`).
+To query a specific ECS image you need to pass `image_id` and `region` in the where clause (`where image_id='' and region=''`).
 
 ## Examples
 
@@ -113,7 +113,7 @@ where
   and image.creation_time <= (current_date - interval '90' day)
 ```
 
-### Get a particular image details
+### Get details of a particular image
 
 ```sql
 select
@@ -127,6 +127,5 @@ from
   alicloud_ecs_image
 where
   image_id = 'centos_7_9_x64_20G_alibase_20221129.vhd'
-and
-  region = 'us-east-1';
+  and region = 'us-east-1';
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, image_id, size, status, image_owner_alias, architecture from alicloud_ecs_image where image_id = 'centos_7_9_x64_20G_alibase_20221129.vhd' and region = 'us-east-1'
+-----------------------------------------+-----------------------------------------+------+-----------+-------------------+--------------+
| name                                    | image_id                                | size | status    | image_owner_alias | architecture |
+-----------------------------------------+-----------------------------------------+------+-----------+-------------------+--------------+
| centos_7_9_x64_20G_alibase_20221129.vhd | centos_7_9_x64_20G_alibase_20221129.vhd | 20   | Available | system            | x86_64       |
+-----------------------------------------+-----------------------------------------+------+-----------+-------------------+--------------+
```
</details>
