### PR TITLE
Fixed alicloud_slb_load_balancer listSlbLoadBalancers failed with panic interface conversion Closes #480

### DIFF
--- a/alicloud/service.go
+++ b/alicloud/service.go
@@ -275,7 +275,7 @@ func SLBService(ctx context.Context, d *plugin.QueryData) (*slb.Client, error) {
 	region := GetDefaultRegion(d.Connection)
 
 	// have we already created and cached the service?
-	serviceCacheKey := fmt.Sprintf("ram-%s", region)
+	serviceCacheKey := fmt.Sprintf("slb-%s", region)
 	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
 		return cachedData.(*slb.Client), nil
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/alicloud_slb_load_balancer []

PRETEST: tests/alicloud_slb_load_balancer

TEST: tests/alicloud_slb_load_balancer
Running terraform
data.alicloud_caller_identity.current: Reading...
alicloud_vpc.named_test_resource: Refreshing state... [id=vpc-0xi1j4zzsvvp30ig8myqc]
data.alicloud_caller_identity.current: Read complete after 1s [id=295372922530649815]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]
alicloud_vswitch.named_test_resource: Refreshing state... [id=vsw-0xi1ylhxnmk67pv1mhnvw]
alicloud_slb_load_balancer.named_test_resource: Refreshing state... [id=lb-7gofiyh9hsyuv5xuulwui]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # alicloud_slb_load_balancer.named_test_resource will be updated in-place
  ~ resource "alicloud_slb_load_balancer" "named_test_resource" {
        id                             = "lb-7gofiyh9hsyuv5xuulwui"
      ~ load_balancer_name             = "turbottest69866" -> "turbottest5512"
        name                           = "turbottest69866"
        tags                           = {
            "info" = "create for internet"
        }
        # (17 unchanged attributes hidden)
    }

  # alicloud_vpc.named_test_resource will be updated in-place
  ~ resource "alicloud_vpc" "named_test_resource" {
        id                             = "vpc-0xi1j4zzsvvp30ig8myqc"
        name                           = "turbottest69866"
        tags                           = {}
      ~ vpc_name                       = "turbottest69866" -> "turbottest5512"
        # (15 unchanged attributes hidden)
    }

  # alicloud_vswitch.named_test_resource will be updated in-place
  ~ resource "alicloud_vswitch" "named_test_resource" {
        id                = "vsw-0xi1ylhxnmk67pv1mhnvw"
        name              = "turbottest69866"
        tags              = {}
      ~ vswitch_name      = "turbottest69866" -> "turbottest5512"
        # (8 unchanged attributes hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.

Changes to Outputs:
  ~ resource_name    = "turbottest69866" -> "turbottest5512"
alicloud_vpc.named_test_resource: Modifying... [id=vpc-0xi1j4zzsvvp30ig8myqc]
alicloud_vpc.named_test_resource: Still modifying... [id=vpc-0xi1j4zzsvvp30ig8myqc, 10s elapsed]
alicloud_vpc.named_test_resource: Modifications complete after 10s [id=vpc-0xi1j4zzsvvp30ig8myqc]
alicloud_vswitch.named_test_resource: Modifying... [id=vsw-0xi1ylhxnmk67pv1mhnvw]
alicloud_vswitch.named_test_resource: Modifications complete after 1s [id=vsw-0xi1ylhxnmk67pv1mhnvw]
alicloud_slb_load_balancer.named_test_resource: Modifying... [id=lb-7gofiyh9hsyuv5xuulwui]
alicloud_slb_load_balancer.named_test_resource: Modifications complete after 4s [id=lb-7gofiyh9hsyuv5xuulwui]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 20, in data "null_data_source" "resource":
  20: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 0 added, 3 changed, 0 destroyed.

Outputs:

account_id = "****11149915****"
resource_address = "10.10.9.69"
resource_id = "lb-7gofiyh9hsyuv5xuulwui"
resource_name = "turbottest5512"
vpc_id = "vpc-0xi1j4zzsvvp30ig8myqc"

Running SQL query: test-get-query.sql
[
  {
    "load_balancer_id": "lb-7gofiyh9hsyuv5xuulwui",
    "load_balancer_name": "turbottest5512",
    "load_balancer_status": "active",
    "vpc_id": "vpc-0xi1j4zzsvvp30ig8myqc"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "address": "10.10.9.69",
    "load_balancer_id": "lb-7gofiyh9hsyuv5xuulwui",
    "load_balancer_name": "turbottest5512"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
[]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "load_balancer_name": "turbottest5512",
    "title": "turbottest5512"
  }
]
✔ PASSED

POSTTEST: tests/alicloud_slb_load_balancer

TEARDOWN: tests/alicloud_slb_load_balancer

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from alicloud_slb_load_balancer
+--------------------+--------------------------+----------------------+------------+--------------+---------------------------+---------------------------+--------------+----------------+---------------+----------------------+---------------------------+-------------->
| load_balancer_name | load_balancer_id         | load_balancer_status | address    | address_type | v_switch_id               | vpc_id                    | network_type | master_zone_id | slave_zone_id | internet_charge_type | create_time               | create_time_s>
+--------------------+--------------------------+----------------------+------------+--------------+---------------------------+---------------------------+--------------+----------------+---------------+----------------------+---------------------------+-------------->
| turbottest69866    | lb-7gofiyh9hsyuv5xuulwui | active               | 10.10.9.69 | intranet     | vsw-0xi1ylhxnmk67pv1mhnvw | vpc-0xi1j4zzsvvp30ig8myqc | vpc          | us-east-1a     | us-east-1b    | 4                    | 2024-12-17T22:40:00+05:30 | 2024-12-17T14>
+--------------------+--------------------------+----------------------+------------+--------------+---------------------------+---------------------------+--------------+----------------+---------------+----------------------+---------------------------+-------------->

```
</details>
