### PR TITLE
Fixed alicloud_alidns_domain failed for column 'create_timestamp' Closes #479

### DIFF
--- a/alicloud/table_alicloud_alidns_domain.go
+++ b/alicloud/table_alicloud_alidns_domain.go
@@ -62,7 +62,7 @@ func tableAlicloudAlidnsDomain(ctx context.Context) *plugin.Table {
 				Name:        "create_timestamp",
 				Description: "The timestamp when the domain was created.",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("CreateTimestamp").Transform(transform.UnixToTimestamp),
+				Transform:   transform.FromField("CreateTimestamp").Transform(transform.UnixMsToTimestamp),
 			},
 			{
 				Name:        "record_count",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
