### PR TITLE
Added support for profile authentication for the OSS service Closes #475

### DIFF
--- a/alicloud/service.go
+++ b/alicloud/service.go
@@ -399,14 +399,7 @@ func OssService(ctx context.Context, d *plugin.QueryData, region string) (*oss.C
 		return nil, fmt.Errorf("failed to retrieve credentials from the provider: %v", err)
 	}
 
-	// Validate the retrieved credentials and set up the OSS client
-	if profileCred.AccessKeyId != "" && profileCred.AccessKeySecret != "" && profileCred.SecurityToken != "" {
-		ossCfg.CredentialsProvider = ossCred.NewStaticCredentialsProvider(profileCred.AccessKeyId, profileCred.AccessKeySecret, profileCred.SecurityToken)
-	} else if profileCred.AccessKeyId != "" && profileCred.AccessKeySecret != "" {
-		ossCfg.CredentialsProvider = ossCred.NewStaticCredentialsProvider(profileCred.AccessKeyId, profileCred.AccessKeySecret)
-	} else {
-		return nil, fmt.Errorf("unsupported credential provider '%s' for OSS service authentication", profileCred.ProviderName)
-	}
+	ossCfg.CredentialsProvider = ossCred.NewStaticCredentialsProvider(profileCred.AccessKeyId, profileCred.AccessKeySecret, profileCred.SecurityToken)
 
 	// Initialize and return the OSS client
 	svc := oss.NewClient(ossCfg)

--- a/alicloud/table_alicloud_oss_bucket.go
+++ b/alicloud/table_alicloud_oss_bucket.go
@@ -169,10 +169,6 @@ func listBucket(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 		for _, i := range p.Buckets {
 			d.StreamListItem(ctx, i)
 		}
-
-		if p.IsTruncated {
-			return nil, nil
-		}
 	}
 	return nil, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/Microsoft/hcsshim v0.11.5 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.2.0 // indirect
 	github.com/allegro/bigcache/v3 v3.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.183 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/aliyun/alibaba-cloud-sdk-go v1.63.17 h1:hdhcJzcnwFg5/aM4kmz9EY8sV6IVYnzJTmtYwNrFjmY=
 github.com/aliyun/alibaba-cloud-sdk-go v1.63.17/go.mod h1:SOSDHfe1kX91v3W5QiBsWSLqeLxImobbMX1mxrFHsVQ=
+github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.2.0 h1:gUWBCekWIFWYK7jXhRvPHIa7mRhJih2BGPjzvzodO18=
+github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.2.0/go.mod h1:FTzydeQVmR24FI0D6XWUOMKckjXehM/jgMn1xC+DA9M=
 github.com/aliyun/aliyun-oss-go-sdk v2.1.6+incompatible h1:Ft+KeWIJxFP76LqgJbvtOA1qBIoC8vGkTV3QeCOeJC4=
 github.com/aliyun/aliyun-oss-go-sdk v2.1.6+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3bSzwk=


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from alicloud_oss_bucket;
+------------------+--------------------------------+----------------+---------------------------+---------------+-----------------+------------+---------+------------------------+-----------------+---------+--------+----------+--------+------------------+------------->
| name             | arn                            | location       | creation_date             | storage_class | redundancy_type | versioning | acl     | server_side_encryption | lifecycle_rules | logging | policy | tags_src | tags   | title            | akas        >
+------------------+--------------------------------+----------------+---------------------------+---------------+-----------------+------------+---------+------------------------+-----------------+---------+--------+----------+--------+------------------+------------->
| powerpipe-bucket | arn:acs:oss:::powerpipe-bucket | oss-cn-beijing | 2024-03-01T02:07:11+05:30 | Standard      | <null>          | <null>     | private | {"SSEAlgorithm":""}    | <null>          | <null>  | <null> | <null>   | <null> | powerpipe-bucket | ["arn:acs:os>
+------------------+--------------------------------+----------------+---------------------------+---------------+-----------------+------------+---------+------------------------+-----------------+---------+--------+----------+--------+------------------+------------->

```
</details>
