### PR TITLE
fix: add ap-southeast-8 to supported regions list

### DIFF
--- a/alicloud/multi_region.go
+++ b/alicloud/multi_region.go
@@ -37,7 +37,7 @@ func BuildRegionList(_ context.Context, d *plugin.QueryData) []map[string]interf
 
 func getInvalidRegions(regions []string) []string {
 	alicloudRegions := []string{
-		"cn-beijing", "cn-beijing-finance-1", "cn-chengdu", "cn-guangzhou", "cn-hangzhou", "cn-heyuan", "cn-hongkong", "cn-huhehaote", "cn-qingdao", "cn-shanghai", "cn-shanghai-finance-1", "cn-shenzhen", "cn-shenzhen-finance-1", "cn-wulanchabu", "cn-zhangjiakou", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-5", "ap-southeast-6", "ap-southeast-7", "eu-central-1", "eu-west-1", "me-east-1", "me-central-1", "us-east-1", "us-west-1", "cn-wuhan-lr", "cn-nanjing", "cn-fuzhou",
+		"cn-beijing", "cn-beijing-finance-1", "cn-chengdu", "cn-guangzhou", "cn-hangzhou", "cn-heyuan", "cn-hongkong", "cn-huhehaote", "cn-qingdao", "cn-shanghai", "cn-shanghai-finance-1", "cn-shenzhen", "cn-shenzhen-finance-1", "cn-wulanchabu", "cn-zhangjiakou", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-5", "ap-southeast-6", "ap-southeast-7", "ap-southeast-8", "eu-central-1", "eu-west-1", "me-east-1", "me-central-1", "us-east-1", "us-west-1", "cn-wuhan-lr", "cn-nanjing", "cn-fuzhou",
 	}
 
 	invalidRegions := []string{}


### PR DESCRIPTION
Add the missing ap-southeast-8 (Kuching, Malaysia) region to the validated region list so connection configs can use it for ECS and other multi-region queries.

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
